### PR TITLE
Fix the syntax error in a64.sh

### DIFF
--- a/a64.sh
+++ b/a64.sh
@@ -94,7 +94,7 @@ else
     	
     	echo
     	ee "\e[32mPartial Java was successfully installed!"
-    	ee "Check it by running \e[34mjava --version from terminal after restarting termux\e[0m
+    	ee "Check it by running \e[34mjava --version from terminal after restarting termux\e[0m"
     	echo
     else 
         echo


### PR DESCRIPTION
It prevented script from running by giving unable to find matching '"' and unexpected EOF error